### PR TITLE
FEAT: add microphone access on android 11

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ def getSendgridApiKey() {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     signingConfigs {
         release {
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "de.suitepad.linbridge"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
 
         versionCode 1050340
         versionName "1.5.3"
@@ -55,6 +55,11 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
 }
 
 repositories {
@@ -70,8 +75,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
     implementation 'de.suitepad:linbridge-api:1.1.0'
     implementation "org.linphone.no-video:linphone-sdk-android-debug:4.3.5"
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation group: 'com.jakewharton.timber', name: 'timber', version: '4.7.1'
     implementation ('com.github.danysantiago:sendgrid-android:1') {
         exclude group: 'org.apache.httpcomponents.httpclient-android'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <application
         android:name=".BridgeApplication"
@@ -37,7 +38,8 @@
         <service
             android:name=".BridgeService"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:foregroundServiceType="microphone">
             <intent-filter>
                 <action android:name="de.suitepad.linbridge.BridgeService" />
             </intent-filter>

--- a/app/src/main/java/de/suitepad/linbridge/BridgeService.kt
+++ b/app/src/main/java/de/suitepad/linbridge/BridgeService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.*
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -47,7 +48,11 @@ class BridgeService : Service(), IBridgeService {
         copyIfNotExists(this, R.raw.toy_mono, "$baseDir/toymono.wav")
         copyIfNotExists(this, R.raw.lp_default, "$baseDir/linphonerc")
 
-        startForeground(1, createNotification())
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(1, createNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+        } else {
+            startForeground(1, createNotification())
+        }
         startService()
     }
 


### PR DESCRIPTION
This will enable the service to start as a foreground service to access
the microphone