### PR TITLE
FIX: receiver says busy after ringing for 1-2 seconds

### DIFF
--- a/app/src/main/java/de/suitepad/linbridge/manager/LinbridgeManager.kt
+++ b/app/src/main/java/de/suitepad/linbridge/manager/LinbridgeManager.kt
@@ -39,6 +39,7 @@ class LinbridgeManager @Inject constructor(
         core.ringback = "$baseDir/ringback.wav"
         defaultRingtonePath = "$baseDir/toymono.wav"
         core.ring = null
+        core.incTimeout = 40
 
         core.clearAllAuthInfo()
         core.clearProxyConfig()
@@ -245,6 +246,7 @@ class LinbridgeManager @Inject constructor(
     }
 
     override fun onCallStateChanged(core: Core, call: Call, cstate: Call.State?, message: String) {
+        Timber.i("::: incTimeout = ${core.incTimeout} ::: inCallTimeout = ${core.inCallTimeout}")
         super.onCallStateChanged(core, call, cstate, message)
         callEndReason = call.reason?.toString()?.let { CallEndReason.valueOf(it) } ?: CallEndReason.None
     }


### PR DESCRIPTION
Seems like because of an internal bug, sometimes linphone sets the `incTimeout` value to 0 when a tablet receives a call; this causes the call to end after 1-2 seconds with a message saying "Busy here". Setting a default `incTimeout` fixes this issue.

ref: #bell-173