### PR TITLE
FIX: linbridge crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
-    implementation 'de.suitepad:linbridge-api:1.1.0'
+    implementation 'de.suitepad:linbridge-api:1.1.1'
     // Here is the versions: https://download.linphone.org/releases/android/maven_repository/org/linphone/linphone-sdk-android/
     implementation "org.linphone.no-video:linphone-sdk-android:5.1.37"
     implementation "androidx.appcompat:appcompat:1.4.1"


### PR DESCRIPTION
Because of a missing enum that linphone uses, linbridge crashed sometimes.

ref: #bell-172