### PR TITLE
Fix: MK4 voice cutouts

### DIFF
--- a/app/src/main/java/de/suitepad/linbridge/manager/LinbridgeManager.kt
+++ b/app/src/main/java/de/suitepad/linbridge/manager/LinbridgeManager.kt
@@ -559,20 +559,37 @@ fun Core.getConfiguration(): AudioConfiguration {
 fun Core.maybeConfigureDevice() {
     when (Build.VERSION.SDK_INT) {
         Build.VERSION_CODES.Q -> {
-            isEchoLimiterEnabled = false
+            // Specific configuration for MK4 devices (running Android 10)
+            // needs to be paired with EngineeringMode mic gain = 208
+
+            // gain settings (will be applied on top of EngineeringMode App gain settings)
+            micGainDb = 3.0f
+            playbackGainDb = 3.0f
+
+            // misc settings
+            isAdaptiveRateControlEnabled = true
+            config.setString("sound", "el_type", "mic")
+
+            // echo canceller settings
             isEchoCancellationEnabled = true
+            isEchoLimiterEnabled = false
 
+            // noise gate configuration
+            // ideal settings as per test Burak/Frank 13-Jan-2026
             config.setInt("sound", "noisegate", 1)
-            config.setFloat("sound", "ng_thres", 0.06f)
-            config.setFloat("sound", "ng_floorgain", 0.03f)
+            config.setFloat("sound", "ng_thres", 0.02f)
+            config.setFloat("sound", "ng_floorgain", 0.5f)
 
+            // more configuration
             config.setInt("sound", "echocancellation", 1)
             config.setInt("sound", "echolimiter", 0)
-            config.setInt("sound", "agc", 1)
+            config.setFloat("sound", "mic_gain_db", 3.0f);
+            config.setFloat("sound", "playback_gain_db", 3.0f);
+            config.setInt("sound", "agc", 0) // AGC off -> doesn't do much, can confuse the noise gate
             config.setInt("sound", "ec_tail_len", 250)
             mediastreamerFactory.setDeviceInfo(
                 "alps", "tb8168p1_64_l_d4x_qy_fhd_bsp", "mt8168",
-                org.linphone.mediastream.Factory.DEVICE_HAS_BUILTIN_AEC_CRAPPY, 0, 250
+                org.linphone.mediastream.Factory.DEVICE_HAS_BUILTIN_AEC_CRAPPY, 250, 0
             )
         }
     }

--- a/app/src/main/java/de/suitepad/linbridge/manager/LinbridgeManager.kt
+++ b/app/src/main/java/de/suitepad/linbridge/manager/LinbridgeManager.kt
@@ -560,7 +560,7 @@ fun Core.maybeConfigureDevice() {
     when (Build.VERSION.SDK_INT) {
         Build.VERSION_CODES.Q -> {
             // Specific configuration for MK4 devices (running Android 10)
-            // needs to be paired with EngineeringMode mic gain = 208
+            // needs to be paired with EngineeringMode mic gain = 200
 
             // gain settings (will be applied on top of EngineeringMode App gain settings)
             micGainDb = 3.0f
@@ -577,7 +577,7 @@ fun Core.maybeConfigureDevice() {
             // noise gate configuration
             // ideal settings as per test Burak/Frank 13-Jan-2026
             config.setInt("sound", "noisegate", 1)
-            config.setFloat("sound", "ng_thres", 0.02f)
+            config.setFloat("sound", "ng_thres", 0.015f)
             config.setFloat("sound", "ng_floorgain", 0.5f)
 
             // more configuration


### PR DESCRIPTION
This commit mainly changes the configuration of the MK4-specific noise gate to ideal settings as per testing done on 13-Jan-2026 by Burak and Frank. It also adds some more gain to linbridge itself, which is layered on top of the EngineeringMode gain settings.
Further, AGC is disabled, since it doesn't really do much, but can confuse the noise gate.
Finally, a typo is fixed in the setDeviceInfo() call. 250ms delay for the echo canceller is now set in the right place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines MK4-specific audio tuning on Android 10 to reduce voice cutouts and stabilize levels.
> 
> - Applies MK4 settings in `Core.maybeConfigureDevice()` (SDK Q): enable echo cancellation, keep echo limiter off, enable adaptive rate control, set `el_type` to `mic`
> - Sets +3 dB `micGainDb`/`playbackGainDb` and persists via `config` (`mic_gain_db`, `playback_gain_db`)
> - Noise gate: enable (`noisegate=1`), adjust `ng_thres` to `0.015` and `ng_floorgain` to `0.5`
> - Disables AGC (`agc=0`), sets echo canceller tail length (`ec_tail_len=250`)
> - Fixes `mediastreamerFactory.setDeviceInfo(...)` parameter order so the 250 ms AEC delay is applied to the correct field
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2bf9265b3508914c5ba03b85f52c1b2ca0fedfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->