### PR TITLE
Fix: Build Failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,8 +114,8 @@ dependencies {
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:27.1.0"))
     implementation("com.google.firebase:firebase-crashlytics-ktx:17.1.0")
-   // implementation("org.linphone:linphone-sdk-android:5.5+")
-    implementation("org.linphone.no-video:linphone-sdk-android:5.4.1-pre.11+94bf69bf")
+    //implementation("org.linphone:linphone-sdk-android:5.5+")
+    implementation("org.linphone.no-video:linphone-sdk-android:5.4.1")
 }
 
 apply(plugin = "com.google.gms.google-services")


### PR DESCRIPTION
A specific pre-release version of linphone sdk was tagged in gradle, which no longer exists. Changed to the final build of the same version.
This is also the same version that was tested in the debug build by Kiru and Emelie.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins the Linphone SDK to a stable release to resolve build issues.
> 
> - Replaces pre-release `org.linphone.no-video:linphone-sdk-android:5.4.1-pre.11+94bf69bf` with stable `5.4.1` in `app/build.gradle.kts`
> - Keeps the alternative `org.linphone:linphone-sdk-android` dependency commented out
> - No app code changes; build script dependency update only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c72e4c55aedf5f9883d2690b3f1b5afc54a24d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->