### PR TITLE
2.0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,6 @@ jobs:
           echo $GOOGLE_SERVICES | base64 -d > app/google-services.json
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
       - name: Assemble Release
         run: |
           docker compose run app ./gradlew androidDependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+### 2.0.8
+- Fix: Build Failure
+- Fix: MK4 voice cutouts
+
 ### 2.0.6
 - FEAT: SRV Failover + remove deprecation
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         minSdk = 23
         targetSdk = 33
 
-        versionCode = 2000640
-        versionName = "2.0.6"
+        versionCode = 2000840
+        versionName = "2.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "SENDGRID_MAIL_TO", "\"${getDestinationEmailAddress()}\"")


### PR DESCRIPTION
- Fix: Build Failure
- Fix: MK4 voice cutouts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares 2.0.8 release and streamlines CI.
> 
> - Bumps `versionCode`/`versionName` in `app/build.gradle.kts` to `2000840` / `2.0.8`
> - Updates `CHANGELOG.md` with 2.0.8 fixes (build failure, MK4 voice cutouts)
> - Removes `Setup tmate session` step from `release.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83c8316d798df731fd475adb35fc772b50e0ef88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->