### PR TITLE
Re-Enable tag-based releases in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ name: Release
 
 on:
   push:
-    # tags:
-    #   - '*.*.*'
+    tags:
+      - '*.*.*'
 
 jobs:
   release:


### PR DESCRIPTION
Uncomment and enable the tags trigger in .github/workflows/release.yml so that pushes of tags matching '*.*.*' will run the release job. Previously the tags trigger was commented out.