### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+### 2.1.0
+- fix: stop audio state from being enforced in the Linphone iterate loop
+- Enable tag-based releases in workflow
+- Update Linphone Maven repository URL
+
 ### 2.0.8
 - Fix: Build Failure
 - Fix: MK4 voice cutouts

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         minSdk = 23
         targetSdk = 33
 
-        versionCode = 2000840
-        versionName = "2.0.8"
+        versionCode = 2010040
+        versionName = "2.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "SENDGRID_MAIL_TO", "\"${getDestinationEmailAddress()}\"")


### PR DESCRIPTION
- fix: stop audio state from being enforced in the Linphone iterate loop
- Enable tag-based releases in workflow
- Update Linphone Maven repository URL