### PR TITLE
FIX: crash on Android 6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1")
     implementation("de.suitepad:linbridge-api:1.1.4")
-    implementation("dnsjava:dnsjava:3.6.3")
+    implementation("dnsjava:dnsjava:2.1.9")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/app/src/main/java/de/suitepad/linbridge/manager/DnsSrvLookupManager.kt
+++ b/app/src/main/java/de/suitepad/linbridge/manager/DnsSrvLookupManager.kt
@@ -34,9 +34,8 @@ object DnsSrvLookupManager {
                 withContext(Dispatchers.Main) {
                     onResult(srvRecords)
                 }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 onError(e)
-
             }
         }
     }


### PR DESCRIPTION
Linbridge 2.1.0 would crash on older devices with Android 6, because of incompatible libs -> backported